### PR TITLE
feat(makernote): add MakerNote parser interface and registry

### DIFF
--- a/internal/parser/tiff/ifd.go
+++ b/internal/parser/tiff/ifd.go
@@ -3,6 +3,7 @@ package tiff
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	imxbin "github.com/gomantics/imx/internal/binary"
@@ -11,7 +12,7 @@ import (
 )
 
 // parseIFD parses an IFD at the given offset
-func (p *Parser) parseIFD(r *imxbin.Reader, offset int64, dirName string, iccDirs, iptcDirs, xmpDirs *[]parser.Directory, sharedParseErr *parser.ParseError) (*parser.Directory, *parser.ParseError, []SubIFD, uint16) {
+func (p *Parser) parseIFD(r *imxbin.Reader, fileReader io.ReaderAt, offset int64, dirName string, iccDirs, iptcDirs, xmpDirs, makernoteDirs *[]parser.Directory, sharedParseErr *parser.ParseError) (*parser.Directory, *parser.ParseError, []SubIFD, uint16) {
 	var parseErr *parser.ParseError
 	if sharedParseErr != nil {
 		// Use shared error accumulator for multi-IFD parsing
@@ -60,6 +61,8 @@ func (p *Parser) parseIFD(r *imxbin.Reader, offset int64, dirName string, iccDir
 			p.handleIPTC(r, entry, parseErr, iptcDirs)
 		case TagXMP:
 			p.handleXMP(r, entry, parseErr, xmpDirs)
+		case TagMakerNote:
+			p.handleMakerNote(r, fileReader, entry, &dir.Tags, parseErr, makernoteDirs)
 		default:
 			// Regular tag
 			tag, err := p.parseTag(r, entry, dirName)
@@ -513,6 +516,62 @@ func (p *Parser) handleXMP(r *imxbin.Reader, entry *IFDEntry, parseErr *parser.P
 			parseErr.Merge(xmpErr)
 		}
 		*xmpDirs = append(*xmpDirs, dirs...)
+	}
+}
+
+// handleMakerNote handles MakerNote tag (tag 0x927C)
+// MakerNote contains manufacturer-specific metadata in various formats.
+// When a manufacturer handler is registered and parses successfully, the
+// parsed tags are returned in a separate directory.
+// When no handler matches, the raw MakerNote data is returned as a tag.
+func (p *Parser) handleMakerNote(r *imxbin.Reader, fileReader io.ReaderAt, entry *IFDEntry, dirTags *[]parser.Tag, parseErr *parser.ParseError, makernoteDirs *[]parser.Directory) {
+	// Read MakerNote data
+	makerNoteOffset := int64(entry.ValueOffset)
+	data, err := r.ReadBytes(makerNoteOffset, int(entry.Count))
+	if err != nil {
+		parseErr.Add(fmt.Errorf("failed to read MakerNote data at offset %d: %w", makerNoteOffset, err))
+		return
+	}
+
+	// If no registry or no handler matches, return raw MakerNote as a tag
+	if p.makernote == nil {
+		*dirTags = append(*dirTags, parser.Tag{
+			ID:       parser.TagID("ExifIFD:0x927C"),
+			Name:     "MakerNote",
+			Value:    data,
+			DataType: "UNDEFINED",
+		})
+		return
+	}
+
+	handler, cfg := p.makernote.Detect(data)
+	if handler == nil {
+		// Unknown manufacturer - return raw data as tag
+		*dirTags = append(*dirTags, parser.Tag{
+			ID:       parser.TagID("ExifIFD:0x927C"),
+			Name:     "MakerNote",
+			Value:    data,
+			DataType: "UNDEFINED",
+		})
+		return
+	}
+
+	// Detect manufacturer and parse
+	// exifBase is 0 for standard TIFF files (TIFF header at file start)
+	// TODO: For JPEG files, this would need to be the APP1 EXIF header offset
+	exifBase := int64(0)
+
+	tags, mnErr := handler.Parse(fileReader, makerNoteOffset, exifBase, cfg)
+	if mnErr != nil {
+		parseErr.Merge(mnErr)
+	}
+
+	// Create directory for MakerNote tags if any were parsed
+	if len(tags) > 0 {
+		*makernoteDirs = append(*makernoteDirs, parser.Directory{
+			Name: handler.Manufacturer(),
+			Tags: tags,
+		})
 	}
 }
 

--- a/internal/parser/tiff/ifd_test.go
+++ b/internal/parser/tiff/ifd_test.go
@@ -163,8 +163,9 @@ func TestParser_parseIFD(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			reader := imxbin.NewReader(bytes.NewReader(tt.data), order)
-			var iccDirs, iptcDirs, xmpDirs []parser.Directory
+			fileReader := bytes.NewReader(tt.data)
+			reader := imxbin.NewReader(fileReader, order)
+			var iccDirs, iptcDirs, xmpDirs, makernoteDirs []parser.Directory
 
 			// Test both with shared error and without
 			var parseErr *parser.ParseError
@@ -174,7 +175,7 @@ func TestParser_parseIFD(t *testing.T) {
 			} else {
 				parseErr = parser.NewParseError()
 			}
-			dir, _, subIFDs, numEntries := p.parseIFD(reader, 0, "IFD0", &iccDirs, &iptcDirs, &xmpDirs, parseErr)
+			dir, _, subIFDs, numEntries := p.parseIFD(reader, fileReader, 0, "IFD0", &iccDirs, &iptcDirs, &xmpDirs, &makernoteDirs, parseErr)
 
 			if (dir != nil) != tt.wantDir {
 				t.Errorf("dir = %v, wantDir %v", dir != nil, tt.wantDir)

--- a/internal/parser/tiff/makernote/config.go
+++ b/internal/parser/tiff/makernote/config.go
@@ -1,0 +1,42 @@
+package makernote
+
+import "encoding/binary"
+
+// OffsetBase determines how tag value offsets are calculated.
+type OffsetBase int
+
+const (
+	// OffsetAbsolute means offsets are relative to EXIF TIFF header.
+	// Used by: Canon, Nikon Type 1/2, Sony
+	OffsetAbsolute OffsetBase = iota
+
+	// OffsetRelativeToMakerNote means offsets are relative to MakerNote start.
+	// Used by: Fujifilm, Nikon Type 3
+	OffsetRelativeToMakerNote
+)
+
+// Config holds manufacturer-specific parsing configuration.
+// Returned by Handler.Detect() to configure parsing behavior.
+type Config struct {
+	// IFDOffset is where the IFD starts within the MakerNote data.
+	// For Canon: 0 (no header)
+	// For Nikon Type 1: 8 (after 8-byte header)
+	// For Nikon Type 3: 18 (after 10-byte header + 8-byte TIFF header)
+	// For Sony: 12 (after 12-byte header)
+	// For Fujifilm: 12 (after 8-byte header + 4-byte offset)
+	IFDOffset int64
+
+	// OffsetBase determines how tag value offsets are calculated.
+	OffsetBase OffsetBase
+
+	// ByteOrder for parsing. If nil, inherits from parent EXIF.
+	// Nikon Type 3 and Fujifilm have embedded byte order.
+	ByteOrder binary.ByteOrder
+
+	// HasNextIFD indicates if next-IFD pointer should be followed.
+	// Canon CR2 files have non-zero next-IFD that should be ignored.
+	HasNextIFD bool
+
+	// Variant identifies the specific format variant (e.g., "Type1", "Type3").
+	Variant string
+}

--- a/internal/parser/tiff/makernote/makernote.go
+++ b/internal/parser/tiff/makernote/makernote.go
@@ -1,0 +1,235 @@
+// Package makernote provides MakerNote parsing for camera manufacturer-specific metadata.
+//
+// MakerNote is an EXIF tag (0x927C) containing manufacturer-specific metadata.
+// Each manufacturer uses a different format, requiring specialized parsers.
+//
+// Supported manufacturers:
+//   - Canon: No header, IFD at offset 0, absolute offsets
+//   - Nikon: Type 1 (8-byte header), Type 3 (embedded TIFF)
+//   - Sony: 12-byte header, absolute offsets, little-endian
+//   - Fujifilm: 8-byte header + offset, relative offsets, little-endian
+package makernote
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/gomantics/imx/internal/parser"
+)
+
+// Handler defines the interface for manufacturer-specific MakerNote parsers.
+type Handler interface {
+	// Manufacturer returns the manufacturer name (e.g., "Canon", "Nikon").
+	Manufacturer() string
+
+	// Detect checks if this handler can parse the given MakerNote data.
+	// Returns true and a Config if the data matches this manufacturer's format.
+	Detect(data []byte) (bool, *Config)
+
+	// Parse extracts metadata from the MakerNote.
+	// r: reader for the entire file (needed for offset-based reads)
+	// makerNoteOffset: absolute offset of MakerNote in file
+	// exifBase: absolute offset of EXIF TIFF header (for absolute offset calculation)
+	// cfg: parsing configuration from Detect()
+	Parse(r io.ReaderAt, makerNoteOffset, exifBase int64, cfg *Config) ([]parser.Tag, *parser.ParseError)
+
+	// TagName returns the human-readable name for a tag ID.
+	TagName(tagID uint16) string
+}
+
+// Registry manages manufacturer handlers and routes MakerNote data to the appropriate parser.
+type Registry struct {
+	handlers []Handler
+}
+
+// NewRegistry creates a new Registry with no registered handlers.
+func NewRegistry() *Registry {
+	return &Registry{
+		handlers: make([]Handler, 0),
+	}
+}
+
+// Register adds a handler to the registry.
+// Handlers are checked in registration order during detection.
+// Register handlers in priority order: most specific first.
+//
+// Recommended order:
+//  1. Nikon Type 3 ('Nikon' + 0x02)
+//  2. Nikon Type 1 ('Nikon' + 0x01)
+//  3. Sony ('SONY DSC' or 'SONY CAM')
+//  4. Fujifilm ('FUJIFILM')
+//  5. Canon (no header - validated by IFD structure, must be last)
+func (r *Registry) Register(h Handler) {
+	r.handlers = append(r.handlers, h)
+}
+
+// Detect finds the appropriate handler for the given MakerNote data.
+// Returns the handler and its configuration, or nil if no handler matches.
+func (r *Registry) Detect(data []byte) (Handler, *Config) {
+	for _, h := range r.handlers {
+		if ok, cfg := h.Detect(data); ok {
+			return h, cfg
+		}
+	}
+	return nil, nil
+}
+
+// Parse parses MakerNote data using the appropriate manufacturer handler.
+// Returns nil tags (not error) for unknown manufacturers.
+func (r *Registry) Parse(reader io.ReaderAt, makerNoteOffset, exifBase int64, data []byte) ([]parser.Tag, *parser.ParseError) {
+	handler, cfg := r.Detect(data)
+	if handler == nil {
+		// Unknown manufacturer - return nil without error
+		return nil, nil
+	}
+	return handler.Parse(reader, makerNoteOffset, exifBase, cfg)
+}
+
+// Header detection constants
+var (
+	// Nikon headers
+	nikonHeader     = []byte("Nikon")
+	nikonType3Magic = byte(0x02)
+	nikonType1Magic = byte(0x01)
+
+	// Sony headers
+	sonyDSCHeader = []byte("SONY DSC ")
+	sonyCAMHeader = []byte("SONY CAM ")
+
+	// Fujifilm header
+	fujifilmHeader = []byte("FUJIFILM")
+)
+
+// DetectNikonType3 checks for Nikon Type 3 format.
+// Header: 'Nikon' + 0x00 + 0x02 + 0x00 + 0x00 + embedded TIFF header
+func DetectNikonType3(data []byte) (bool, *Config) {
+	if len(data) < 18 {
+		return false, nil
+	}
+
+	// Check 'Nikon' + 0x00 + 0x02
+	if !bytes.HasPrefix(data, nikonHeader) {
+		return false, nil
+	}
+	if data[5] != 0x00 || data[6] != nikonType3Magic {
+		return false, nil
+	}
+
+	// Read embedded TIFF header byte order at offset 10
+	var order binary.ByteOrder
+	if data[10] == 'I' && data[11] == 'I' {
+		order = binary.LittleEndian
+	} else if data[10] == 'M' && data[11] == 'M' {
+		order = binary.BigEndian
+	} else {
+		return false, nil
+	}
+
+	return true, &Config{
+		IFDOffset:  18, // 10-byte header + 8-byte TIFF header
+		OffsetBase: OffsetRelativeToMakerNote,
+		ByteOrder:  order,
+		HasNextIFD: false,
+		Variant:    "Type3",
+	}
+}
+
+// DetectNikonType1 checks for Nikon Type 1 format.
+// Header: 'Nikon' + 0x00 + 0x01 + 0x00
+func DetectNikonType1(data []byte) (bool, *Config) {
+	if len(data) < 8 {
+		return false, nil
+	}
+
+	// Check 'Nikon' + 0x00 + 0x01
+	if !bytes.HasPrefix(data, nikonHeader) {
+		return false, nil
+	}
+	if data[5] != 0x00 || data[6] != nikonType1Magic {
+		return false, nil
+	}
+
+	return true, &Config{
+		IFDOffset:  8,
+		OffsetBase: OffsetAbsolute,
+		ByteOrder:  nil, // Inherit from parent
+		HasNextIFD: false,
+		Variant:    "Type1",
+	}
+}
+
+// DetectSony checks for Sony format.
+// Header: 'SONY DSC ' or 'SONY CAM ' (12 bytes)
+func DetectSony(data []byte) (bool, *Config) {
+	if len(data) < 12 {
+		return false, nil
+	}
+
+	if !bytes.HasPrefix(data, sonyDSCHeader) && !bytes.HasPrefix(data, sonyCAMHeader) {
+		return false, nil
+	}
+
+	return true, &Config{
+		IFDOffset:  12,
+		OffsetBase: OffsetAbsolute,
+		ByteOrder:  binary.LittleEndian,
+		HasNextIFD: false,
+		Variant:    "Standard",
+	}
+}
+
+// DetectFujifilm checks for Fujifilm format.
+// Header: 'FUJIFILM' (8 bytes) + 4-byte IFD offset (little-endian)
+func DetectFujifilm(data []byte) (bool, *Config) {
+	if len(data) < 12 {
+		return false, nil
+	}
+
+	if !bytes.HasPrefix(data, fujifilmHeader) {
+		return false, nil
+	}
+
+	// Read IFD offset at bytes 8-11 (little-endian)
+	ifdOffset := int64(binary.LittleEndian.Uint32(data[8:12]))
+
+	return true, &Config{
+		IFDOffset:  ifdOffset,
+		OffsetBase: OffsetRelativeToMakerNote,
+		ByteOrder:  binary.LittleEndian,
+		HasNextIFD: false,
+		Variant:    "Standard",
+	}
+}
+
+// DetectCanon checks for Canon format.
+// Canon has no header - the MakerNote starts directly with an IFD.
+// Detection: first 2 bytes form a valid entry count (1-100).
+// This should be called LAST as a fallback.
+func DetectCanon(data []byte) (bool, *Config) {
+	if len(data) < 14 { // Minimum: 2-byte count + one 12-byte entry
+		return false, nil
+	}
+
+	// First 2 bytes are entry count (little-endian assumed, validated later)
+	entryCount := binary.LittleEndian.Uint16(data[0:2])
+
+	// Sanity check: reasonable entry count (1-100)
+	if entryCount < 1 || entryCount > 100 {
+		return false, nil
+	}
+
+	// Additional validation: check if data is large enough for entries
+	requiredSize := 2 + int(entryCount)*12
+	if len(data) < requiredSize {
+		return false, nil
+	}
+
+	return true, &Config{
+		IFDOffset:  0,
+		OffsetBase: OffsetAbsolute,
+		ByteOrder:  nil, // Inherit from parent
+		HasNextIFD: false,
+		Variant:    "Standard",
+	}
+}

--- a/internal/parser/tiff/makernote/makernote_test.go
+++ b/internal/parser/tiff/makernote/makernote_test.go
@@ -1,0 +1,376 @@
+package makernote
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestDetectNikonType3(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantMatch bool
+		wantOrder binary.ByteOrder
+	}{
+		{
+			name: "valid Nikon Type 3 little-endian",
+			data: append(
+				[]byte("Nikon\x00\x02\x00\x00\x00"),  // 10-byte header
+				[]byte("II\x2a\x00\x08\x00\x00\x00")..., // TIFF header LE
+			),
+			wantMatch: true,
+			wantOrder: binary.LittleEndian,
+		},
+		{
+			name: "valid Nikon Type 3 big-endian",
+			data: append(
+				[]byte("Nikon\x00\x02\x00\x00\x00"),
+				[]byte("MM\x00\x2a\x00\x00\x00\x08")...,
+			),
+			wantMatch: true,
+			wantOrder: binary.BigEndian,
+		},
+		{
+			name:      "Nikon Type 1 header - should not match",
+			data:      []byte("Nikon\x00\x01\x00"),
+			wantMatch: false,
+		},
+		{
+			name:      "too short",
+			data:      []byte("Nikon\x00\x02"),
+			wantMatch: false,
+		},
+		{
+			name:      "invalid byte order marker",
+			data:      append([]byte("Nikon\x00\x02\x00\x00\x00"), []byte("XX\x2a\x00\x08\x00\x00\x00")...),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, cfg := DetectNikonType3(tt.data)
+			if match != tt.wantMatch {
+				t.Errorf("DetectNikonType3() match = %v, want %v", match, tt.wantMatch)
+			}
+			if match {
+				if cfg.ByteOrder != tt.wantOrder {
+					t.Errorf("DetectNikonType3() order = %v, want %v", cfg.ByteOrder, tt.wantOrder)
+				}
+				if cfg.IFDOffset != 18 {
+					t.Errorf("DetectNikonType3() IFDOffset = %d, want 18", cfg.IFDOffset)
+				}
+				if cfg.OffsetBase != OffsetRelativeToMakerNote {
+					t.Errorf("DetectNikonType3() OffsetBase = %v, want OffsetRelativeToMakerNote", cfg.OffsetBase)
+				}
+				if cfg.Variant != "Type3" {
+					t.Errorf("DetectNikonType3() Variant = %s, want Type3", cfg.Variant)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectNikonType1(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantMatch bool
+	}{
+		{
+			name:      "valid Nikon Type 1",
+			data:      []byte("Nikon\x00\x01\x00"),
+			wantMatch: true,
+		},
+		{
+			name:      "Nikon Type 3 header - should not match",
+			data:      []byte("Nikon\x00\x02\x00\x00\x00IIII"),
+			wantMatch: false,
+		},
+		{
+			name:      "too short",
+			data:      []byte("Nikon\x00"),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, cfg := DetectNikonType1(tt.data)
+			if match != tt.wantMatch {
+				t.Errorf("DetectNikonType1() match = %v, want %v", match, tt.wantMatch)
+			}
+			if match {
+				if cfg.IFDOffset != 8 {
+					t.Errorf("DetectNikonType1() IFDOffset = %d, want 8", cfg.IFDOffset)
+				}
+				if cfg.OffsetBase != OffsetAbsolute {
+					t.Errorf("DetectNikonType1() OffsetBase = %v, want OffsetAbsolute", cfg.OffsetBase)
+				}
+				if cfg.ByteOrder != nil {
+					t.Errorf("DetectNikonType1() ByteOrder = %v, want nil (inherit)", cfg.ByteOrder)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectSony(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantMatch bool
+	}{
+		{
+			name:      "valid SONY DSC",
+			data:      []byte("SONY DSC \x00\x00\x00"),
+			wantMatch: true,
+		},
+		{
+			name:      "valid SONY CAM",
+			data:      []byte("SONY CAM \x00\x00\x00"),
+			wantMatch: true,
+		},
+		{
+			name:      "too short",
+			data:      []byte("SONY DSC"),
+			wantMatch: false,
+		},
+		{
+			name:      "wrong header",
+			data:      []byte("SONY ABC \x00\x00\x00"),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, cfg := DetectSony(tt.data)
+			if match != tt.wantMatch {
+				t.Errorf("DetectSony() match = %v, want %v", match, tt.wantMatch)
+			}
+			if match {
+				if cfg.IFDOffset != 12 {
+					t.Errorf("DetectSony() IFDOffset = %d, want 12", cfg.IFDOffset)
+				}
+				if cfg.OffsetBase != OffsetAbsolute {
+					t.Errorf("DetectSony() OffsetBase = %v, want OffsetAbsolute", cfg.OffsetBase)
+				}
+				if cfg.ByteOrder != binary.LittleEndian {
+					t.Errorf("DetectSony() ByteOrder = %v, want LittleEndian", cfg.ByteOrder)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectFujifilm(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          []byte
+		wantMatch     bool
+		wantIFDOffset int64
+	}{
+		{
+			name:          "valid Fujifilm with offset 12",
+			data:          []byte("FUJIFILM\x0c\x00\x00\x00"),
+			wantMatch:     true,
+			wantIFDOffset: 12,
+		},
+		{
+			name:          "valid Fujifilm with offset 20",
+			data:          []byte("FUJIFILM\x14\x00\x00\x00"),
+			wantMatch:     true,
+			wantIFDOffset: 20,
+		},
+		{
+			name:      "too short",
+			data:      []byte("FUJIFILM"),
+			wantMatch: false,
+		},
+		{
+			name:      "wrong header",
+			data:      []byte("FUJIXXXX\x0c\x00\x00\x00"),
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, cfg := DetectFujifilm(tt.data)
+			if match != tt.wantMatch {
+				t.Errorf("DetectFujifilm() match = %v, want %v", match, tt.wantMatch)
+			}
+			if match {
+				if cfg.IFDOffset != tt.wantIFDOffset {
+					t.Errorf("DetectFujifilm() IFDOffset = %d, want %d", cfg.IFDOffset, tt.wantIFDOffset)
+				}
+				if cfg.OffsetBase != OffsetRelativeToMakerNote {
+					t.Errorf("DetectFujifilm() OffsetBase = %v, want OffsetRelativeToMakerNote", cfg.OffsetBase)
+				}
+				if cfg.ByteOrder != binary.LittleEndian {
+					t.Errorf("DetectFujifilm() ByteOrder = %v, want LittleEndian", cfg.ByteOrder)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectCanon(t *testing.T) {
+	// Canon IFD: 2-byte entry count + 12-byte entries
+	// Create a minimal valid IFD with 2 entries
+	makeCanonIFD := func(entryCount uint16) []byte {
+		data := make([]byte, 2+int(entryCount)*12)
+		binary.LittleEndian.PutUint16(data[0:2], entryCount)
+		return data
+	}
+
+	tests := []struct {
+		name      string
+		data      []byte
+		wantMatch bool
+	}{
+		{
+			name:      "valid Canon with 2 entries",
+			data:      makeCanonIFD(2),
+			wantMatch: true,
+		},
+		{
+			name:      "valid Canon with 50 entries",
+			data:      makeCanonIFD(50),
+			wantMatch: true,
+		},
+		{
+			name:      "valid Canon with 1 entry",
+			data:      makeCanonIFD(1),
+			wantMatch: true,
+		},
+		{
+			name:      "invalid - 0 entries",
+			data:      makeCanonIFD(0),
+			wantMatch: false,
+		},
+		{
+			name:      "invalid - too many entries (101)",
+			data:      []byte{101, 0}, // Entry count 101
+			wantMatch: false,
+		},
+		{
+			name:      "too short",
+			data:      []byte{2, 0}, // 2 entries but no entry data
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, cfg := DetectCanon(tt.data)
+			if match != tt.wantMatch {
+				t.Errorf("DetectCanon() match = %v, want %v", match, tt.wantMatch)
+			}
+			if match {
+				if cfg.IFDOffset != 0 {
+					t.Errorf("DetectCanon() IFDOffset = %d, want 0", cfg.IFDOffset)
+				}
+				if cfg.OffsetBase != OffsetAbsolute {
+					t.Errorf("DetectCanon() OffsetBase = %v, want OffsetAbsolute", cfg.OffsetBase)
+				}
+				if cfg.ByteOrder != nil {
+					t.Errorf("DetectCanon() ByteOrder = %v, want nil (inherit)", cfg.ByteOrder)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectionPriority(t *testing.T) {
+	// Test that detection order is respected by the registry
+	registry := NewRegistry()
+
+	// Create mock handlers for testing priority
+	type mockHandler struct {
+		name   string
+		detect func([]byte) (bool, *Config)
+	}
+
+	// The registry should be populated in the correct order
+	// This test verifies the detection functions don't have false positives
+
+	t.Run("Nikon Type 3 not matched by Type 1", func(t *testing.T) {
+		data := append(
+			[]byte("Nikon\x00\x02\x00\x00\x00"),
+			[]byte("II\x2a\x00\x08\x00\x00\x00")...,
+		)
+		match, _ := DetectNikonType1(data)
+		if match {
+			t.Error("Nikon Type 3 data should not match Type 1 detection")
+		}
+	})
+
+	t.Run("Sony not matched by Fujifilm", func(t *testing.T) {
+		data := []byte("SONY DSC \x00\x00\x00")
+		match, _ := DetectFujifilm(data)
+		if match {
+			t.Error("Sony data should not match Fujifilm detection")
+		}
+	})
+
+	t.Run("Fujifilm not matched by Canon", func(t *testing.T) {
+		// FUJIFILM header would have entry count 0x5546 ('FU') which is > 100
+		data := []byte("FUJIFILM\x0c\x00\x00\x00")
+		match, _ := DetectCanon(data)
+		if match {
+			t.Error("Fujifilm data should not match Canon detection")
+		}
+	})
+
+	_ = registry // Registry tested implicitly via detection functions
+}
+
+func TestRegistryDetect(t *testing.T) {
+	// Create a simple test handler
+	registry := NewRegistry()
+
+	// Test empty registry returns nil
+	handler, cfg := registry.Detect([]byte("test data"))
+	if handler != nil || cfg != nil {
+		t.Error("Empty registry should return nil")
+	}
+}
+
+func TestConfigFields(t *testing.T) {
+	// Verify Config struct has all required fields
+	cfg := &Config{
+		IFDOffset:  12,
+		OffsetBase: OffsetRelativeToMakerNote,
+		ByteOrder:  binary.LittleEndian,
+		HasNextIFD: true,
+		Variant:    "Type3",
+	}
+
+	if cfg.IFDOffset != 12 {
+		t.Errorf("IFDOffset = %d, want 12", cfg.IFDOffset)
+	}
+	if cfg.OffsetBase != OffsetRelativeToMakerNote {
+		t.Errorf("OffsetBase = %v, want OffsetRelativeToMakerNote", cfg.OffsetBase)
+	}
+	if cfg.ByteOrder != binary.LittleEndian {
+		t.Errorf("ByteOrder = %v, want LittleEndian", cfg.ByteOrder)
+	}
+	if !cfg.HasNextIFD {
+		t.Error("HasNextIFD = false, want true")
+	}
+	if cfg.Variant != "Type3" {
+		t.Errorf("Variant = %s, want Type3", cfg.Variant)
+	}
+}
+
+func TestOffsetBaseConstants(t *testing.T) {
+	// Verify OffsetBase constants are defined correctly
+	if OffsetAbsolute != 0 {
+		t.Errorf("OffsetAbsolute = %d, want 0", OffsetAbsolute)
+	}
+	if OffsetRelativeToMakerNote != 1 {
+		t.Errorf("OffsetRelativeToMakerNote = %d, want 1", OffsetRelativeToMakerNote)
+	}
+}

--- a/internal/parser/tiff/tiff.go
+++ b/internal/parser/tiff/tiff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gomantics/imx/internal/parser"
 	"github.com/gomantics/imx/internal/parser/icc"
 	"github.com/gomantics/imx/internal/parser/iptc"
+	"github.com/gomantics/imx/internal/parser/tiff/makernote"
 	"github.com/gomantics/imx/internal/parser/xmp"
 )
 
@@ -32,17 +33,19 @@ import (
 //   - MEF (Mamiya Raw Format) - Mamiya raw files
 //   - MOS (Leaf Raw) - Leaf raw files
 type Parser struct {
-	icc  *icc.Parser
-	iptc *iptc.Parser
-	xmp  *xmp.Parser
+	icc       *icc.Parser
+	iptc      *iptc.Parser
+	xmp       *xmp.Parser
+	makernote *makernote.Registry
 }
 
 // New creates a new TIFF parser
 func New() *Parser {
 	return &Parser{
-		icc:  icc.New(),
-		iptc: iptc.New(),
-		xmp:  xmp.New(),
+		icc:       icc.New(),
+		iptc:      iptc.New(),
+		xmp:       xmp.New(),
+		makernote: makernote.NewRegistry(),
 	}
 }
 
@@ -71,7 +74,7 @@ func (p *Parser) Parse(r io.ReaderAt) ([]parser.Directory, *parser.ParseError) {
 	var dirs []parser.Directory
 
 	// Embedded metadata directories (collected locally for thread safety)
-	var iccDirs, iptcDirs, xmpDirs []parser.Directory
+	var iccDirs, iptcDirs, xmpDirs, makernoteDirs []parser.Directory
 
 	// Read header to determine byte order
 	headerBuf := make([]byte, tiffHeaderSize)
@@ -106,7 +109,7 @@ func (p *Parser) Parse(r io.ReaderAt) ([]parser.Directory, *parser.ParseError) {
 	reader := imxbin.NewReader(r, order)
 
 	// Parse IFD0
-	ifd0Dir, ifd0Err, subIFDs, numEntries := p.parseIFD(reader, ifd0Offset, "IFD0", &iccDirs, &iptcDirs, &xmpDirs, parseErr)
+	ifd0Dir, ifd0Err, subIFDs, numEntries := p.parseIFD(reader, r, ifd0Offset, "IFD0", &iccDirs, &iptcDirs, &xmpDirs, &makernoteDirs, parseErr)
 	if ifd0Err != nil {
 		parseErr.Merge(ifd0Err)
 	}
@@ -116,7 +119,7 @@ func (p *Parser) Parse(r io.ReaderAt) ([]parser.Directory, *parser.ParseError) {
 
 	// Parse sub-IFDs (EXIF, GPS, Interoperability, SubIFDs for RAW previews)
 	for _, sub := range subIFDs {
-		subDir, subErr, _, _ := p.parseIFD(reader, sub.Offset, sub.Name, &iccDirs, &iptcDirs, &xmpDirs, parseErr)
+		subDir, subErr, _, _ := p.parseIFD(reader, r, sub.Offset, sub.Name, &iccDirs, &iptcDirs, &xmpDirs, &makernoteDirs, parseErr)
 		if subErr != nil {
 			parseErr.Merge(subErr)
 		}
@@ -130,7 +133,7 @@ func (p *Parser) Parse(r io.ReaderAt) ([]parser.Directory, *parser.ParseError) {
 	nextIFDOffsetPos := ifd0Offset + ifdEntryCountSize + int64(numEntries)*ifdEntrySize
 	nextIFDOffset, err := reader.ReadUint32(nextIFDOffsetPos)
 	if err == nil && nextIFDOffset != 0 {
-		ifd1Dir, ifd1Err, _, _ := p.parseIFD(reader, int64(nextIFDOffset), "IFD1", &iccDirs, &iptcDirs, &xmpDirs, parseErr)
+		ifd1Dir, ifd1Err, _, _ := p.parseIFD(reader, r, int64(nextIFDOffset), "IFD1", &iccDirs, &iptcDirs, &xmpDirs, &makernoteDirs, parseErr)
 		if ifd1Err != nil {
 			parseErr.Merge(ifd1Err)
 		}
@@ -143,6 +146,7 @@ func (p *Parser) Parse(r io.ReaderAt) ([]parser.Directory, *parser.ParseError) {
 	dirs = append(dirs, iccDirs...)
 	dirs = append(dirs, iptcDirs...)
 	dirs = append(dirs, xmpDirs...)
+	dirs = append(dirs, makernoteDirs...)
 
 	return dirs, parseErr.OrNil()
 }


### PR DESCRIPTION
## Summary
- Implements MNI-1 (Issue #10) - MakerNote parser interface and registry
- Creates extensible foundation for manufacturer-specific MakerNote parsing
- Adds detection functions for Canon, Nikon (T1/T3), Sony, and Fujifilm
- Integrates with TIFF parser via handleMakerNote() in ifd.go

## Test plan
- [x] Unit tests for all detection functions (Nikon T1/T3, Sony, Fujifilm, Canon)
- [x] Tests for detection priority (no false positives between manufacturers)
- [x] Tests for Config struct and OffsetBase constants
- [x] Integration tests pass (MakerNote returned as raw tag when no handler matches)
- [x] All existing tests pass

## Files Changed
| File | Description |
|------|-------------|
| `internal/parser/tiff/makernote/config.go` | Config and OffsetBase types |
| `internal/parser/tiff/makernote/makernote.go` | Handler interface, Registry, detection functions |
| `internal/parser/tiff/makernote/makernote_test.go` | Comprehensive test coverage |
| `internal/parser/tiff/tiff.go` | Registry integration |
| `internal/parser/tiff/ifd.go` | handleMakerNote() function |

## Unblocks
- MNI-2: Canon Parser
- MNI-3: Sony Parser
- MNI-4: Nikon Parser
- MNI-5: Fujifilm Parser

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)