### PR TITLE
fix: display ExifVersion/FlashpixVersion as version strings

### DIFF
--- a/api_integration_test.go
+++ b/api_integration_test.go
@@ -25,14 +25,14 @@ func TestIntegration_JPEG(t *testing.T) {
 				{Name: "CustomRendered", Value: "Portrait HDR"},
 				{Name: "DateTimeDigitized", Value: "2019:09:21 14:43:51"},
 				{Name: "DateTimeOriginal", Value: "2019:09:21 14:43:51"},
-				{Name: "ExifVersion", Value: []byte{48, 50, 50, 49}},
+				{Name: "ExifVersion", Value: "0221"},
 				{Name: "ExposureBiasValue", Value: "0/1"},
 				{Name: "ExposureMode", Value: "Auto"},
 				{Name: "ExposureProgram", Value: "Program AE"},
 				{Name: "ExposureTime", Value: "1/758"},
 				{Name: "FNumber", Value: "9/5"},
 				{Name: "Flash", Value: "Auto, Did not fire"},
-				{Name: "FlashpixVersion", Value: []byte{48, 49, 48, 48}},
+				{Name: "FlashpixVersion", Value: "0100"},
 				{Name: "FocalLength", Value: "17/4"},
 				{Name: "FocalLengthIn35mmFilm", Value: uint16(26)},
 				{Name: "ISOSpeedRatings", Value: uint16(32)},
@@ -272,7 +272,7 @@ func TestIntegration_CR2(t *testing.T) {
 				{Name: "FNumber", Value: "14/10"},
 				{Name: "ExposureProgram", Value: "Program AE"},
 				{Name: "ISOSpeedRatings", Value: uint16(640)},
-				{Name: "ExifVersion", Value: []byte{48, 50, 50, 49}}, // "0221" in hex
+				{Name: "ExifVersion", Value: "0221"},
 				{Name: "DateTimeOriginal", Value: "2004:11:13 23:02:21"},
 				{Name: "DateTimeDigitized", Value: "2004:11:13 23:02:21"},
 				{Name: "ComponentsConfiguration", Value: []byte{1, 2, 3, 0}}, // Y, Cb, Cr, -
@@ -284,7 +284,7 @@ func TestIntegration_CR2(t *testing.T) {
 				{Name: "FocalLength", Value: "85/1"},
 				{Name: "MakerNote", Type: "[]byte"},   // Binary data - check presence only
 				{Name: "UserComment", Type: "[]byte"}, // Binary data - check presence only
-				{Name: "FlashpixVersion", Value: []byte{48, 49, 48, 48}}, // "0100" in hex
+				{Name: "FlashpixVersion", Value: "0100"},
 				{Name: "ColorSpace", Value: "sRGB"},
 				{Name: "PixelXDimension", Value: uint16(4992)},
 				{Name: "PixelYDimension", Value: uint16(3328)},

--- a/internal/parser/tiff/constants.go
+++ b/internal/parser/tiff/constants.go
@@ -39,7 +39,10 @@ const (
 	bufferSizeUint64 = 8
 
 	// Special tag values
-	tagGPSVersionID = 0x0000 // GPS Version ID tag
+	tagGPSVersionID       = 0x0000 // GPS Version ID tag
+	tagExifVersion        = 0x9000 // EXIF Version tag
+	tagFlashpixVersion    = 0xA000 // Flashpix Version tag
+	tagInteropVersion     = 0x0002 // Interoperability Version tag
 
 	// Byte order markers
 	byteOrderLittleEndian = 'I'

--- a/internal/parser/tiff/ifd.go
+++ b/internal/parser/tiff/ifd.go
@@ -118,10 +118,21 @@ func (p *Parser) parseTag(r *imxbin.Reader, entry *IFDEntry, dirName string) (*p
 		return nil, err
 	}
 
-	// Special formatting for GPS Version ID
-	if entry.Tag == tagGPSVersionID && strings.ToLower(dirName) == "gps" {
+	// Special formatting for version tags
+	switch {
+	case entry.Tag == tagGPSVersionID && strings.ToLower(dirName) == "gps":
 		if bytes, ok := value.([]byte); ok && len(bytes) == 4 {
 			value = fmt.Sprintf("%d.%d.%d.%d", bytes[0], bytes[1], bytes[2], bytes[3])
+		}
+	case entry.Tag == tagExifVersion || entry.Tag == tagFlashpixVersion:
+		// ExifVersion/FlashpixVersion are stored as 4 ASCII bytes (e.g., "0230" for 2.30)
+		if bytes, ok := value.([]byte); ok && len(bytes) == 4 {
+			value = string(bytes)
+		}
+	case entry.Tag == tagInteropVersion && strings.ToLower(dirName) == "interoperability":
+		// InteroperabilityVersion is also stored as 4 ASCII bytes
+		if bytes, ok := value.([]byte); ok && len(bytes) == 4 {
+			value = string(bytes)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Convert ExifVersion/FlashpixVersion from raw byte slices to readable strings
- ExifVersion `[]byte{48, 50, 50, 49}` → `"0221"` 
- FlashpixVersion `[]byte{48, 49, 48, 48}` → `"0100"`
- Also handles InteroperabilityVersion in the same way

Fixes #17

## Test plan
- [x] All existing tests pass
- [x] Updated integration test expectations to verify string values

🤖 Generated with [Claude Code](https://claude.com/claude-code)